### PR TITLE
feat(git): Use --strategy=ours only as fallback

### DIFF
--- a/lib/backport.js
+++ b/lib/backport.js
@@ -75,24 +75,27 @@ module.exports = async function (context, targets, logger) {
       const commitsList = target.commits.length > 0 ? target.commits : commits
       logger.debug('Backporting commits', commitsList.join(', '), 'to', target.branch)
 
-      const branch = await git(context, token, commitsList, target.branch, logger)
+      const { backportBranch, conflicts } = await git(context, token, commitsList, target.branch, logger)
 
-      // Check conflicts
+      // Compare diffs
       const oldChanges = await pullRequest.getChanges(context)
       const newChanges = await pullRequest.getChanges(context, newPrId)
-      const conflicts = oldChanges.additions !== newChanges.additions || oldChanges.deletions !== newChanges.deletions
-      logger.debug('Checking conflicts', oldChanges, newChanges)
+      const diffChanges = oldChanges.additions !== newChanges.additions || oldChanges.deletions !== newChanges.deletions
+      logger.debug('Comparing diffs', oldChanges, newChanges)
 
       // Open PR
-      const newPR = await pullRequest.newReady(context, pr.data.number, pr.data.title, target.branch, branch, conflicts)
+      const newPR = await pullRequest.newReady(context, pr.data.number, pr.data.title, target.branch, backportBranch, conflicts || diffChanges)
       newPrId = newPR.data.number
 
       // Add labels
       await pullRequest.addLabels(context, labels, newPrId)
 
       if (conflicts) {
-        logger.warn('Conflicts when cherry-picking from', oldBranch, 'to branch', branch)
-        await pullRequest.updatePRBody(context, newPrId, `- [ ] :warning: This backport had conflicts and is incomplete\n\nbackport of #${pr.data.number}`)
+        logger.warn('Conflicts when cherry-picking from ' + oldBranch + ' to branch ' + backportBranch + ' prevented with --strategy=ours')
+        await pullRequest.updatePRBody(context, newPrId, `- [ ] :warning: This backport had conflicts that were resolved with the 'ours' merge strategy and is likely incomplete\n\nbackport of #${pr.data.number}`)
+      } else if (diffChanges) {
+        logger.warn('Diff changes when cherry-picking from ' + oldBranch + ' to branch ' + backportBranch)
+        await pullRequest.updatePRBody(context, newPrId, `- [ ] :warning: This backport's changes differ from the original and might be incomplete\n\nbackport of #${pr.data.number}`)
       }
 
       // Set available milestone
@@ -101,7 +104,7 @@ module.exports = async function (context, targets, logger) {
         await pullRequest.setMilestone(context, milestoneId, newPrId)
       }
 
-      logger.info('Successfully created backport from', oldBranch, 'for', target.branch, 'in', branch)
+      logger.info('Successfully created backport from', oldBranch, 'for', target.branch, 'in', backportBranch)
     } catch (e) {
       logger.debug(e)
       logger.error('Backport to', target.branch, 'failed')

--- a/lib/git.js
+++ b/lib/git.js
@@ -35,17 +35,27 @@ module.exports = async function (context, token, commits, target, logger) {
       target
     )
 
+    let conflicts = false
     for (let i = 0; i < commits.length; i++) {
       logger.debug('Cherry picking', commits[i])
       // Cherry picking commits while discarding conflicts
-      await git.raw([
-        'cherry-pick',
-        commits[i],
-        '--strategy-option',
-        'ours'
-      ], (err, result) => {
-        logger.info(err, result)
-      })
+      try {
+        await git.raw([
+          'cherry-pick',
+          commits[i],
+        ])
+      } catch (error) {
+        conflicts = true
+
+        await git.raw([
+          'cherry-pick',
+          commits[i],
+          '--strategy-option',
+          'ours'
+        ], (err, result) => {
+          logger.info(err, result)
+        })
+      }
     }
 
     logger.debug('Pushing to', backportBranch)
@@ -59,5 +69,8 @@ module.exports = async function (context, token, commits, target, logger) {
   // Cleanup
   fs.remove(gitRoot)
 
-  return backportBranch
+  return {
+    backportBranch,
+    conflicts,
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/backportbot/issues/189

This PR changes the merge strategy back to the git default and only falls back to --strategy=ours if the default fails.

The warning in the PR description is now also sensible to the type of conflict:

1) If we fall back to --strategy=ours there is likely a conflict to be resolved
2) If only the diff is not equal between the original PR and the backport PR we don't necessarily have a conflict to resolve. If the default merge strategy succeeded we have a successful backport

In both cases the PR will still be opened as draft.