### PR TITLE
fix(github): Don't open PR as draft

### DIFF
--- a/lib/pr.js
+++ b/lib/pr.js
@@ -76,8 +76,7 @@ module.exports = {
       title: '[' + target + '] ' + origPRTitle,
       head: targetBranch,
       base: target,
-      body: `backport of #${origPRnr}`,
-      draft: draft,
+      body: `backport of #${origPRnr}`
     })
     return context.github.pulls.create(params)
   },


### PR DESCRIPTION
There seem to be problems with the current deployment. Reverting draft PRs to localize the issue.