### PR TITLE
fix: always log exceptions during backport

### DIFF
--- a/lib/backport.js
+++ b/lib/backport.js
@@ -106,8 +106,8 @@ module.exports = async function (context, targets, logger) {
 
       logger.info('Successfully created backport from', oldBranch, 'for', target.branch, 'in', backportBranch)
     } catch (e) {
-      logger.debug(e)
       logger.error('Backport to', target.branch, 'failed')
+      logger.error(e)
       success = false
       pullRequest.backportFailed(context, target)
       continue


### PR DESCRIPTION
Makes debugging much easier, as the default log level is `info` and thus we are missing the important messages.