### PR TITLE
fix: scope of conflict variable

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -14,6 +14,7 @@ module.exports = async function (context, token, commits, target, logger) {
 
   const number = pr.getNumber(context)
   const backportBranch = 'backport/' + number + '/' + target
+  let conflicts = false
   try {
     // Clone
     const slug = context.repo().owner + '/' + context.repo().repo
@@ -35,7 +36,6 @@ module.exports = async function (context, token, commits, target, logger) {
       target
     )
 
-    let conflicts = false
     for (let i = 0; i < commits.length; i++) {
       logger.debug('Cherry picking', commits[i])
       // Cherry picking commits while discarding conflicts


### PR DESCRIPTION
This should fix failing backports.

## Logged error message
```
ERROR probot: Backport to stable5.0 failed
ERROR probot: conflicts is not defined
  ReferenceError: conflicts is not defined
      at module.exports (/app/lib/git.js:74:5)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
      at async module.exports (/app/lib/backport.js:78:45)
      at async Command.callback (/app/index.js:50:21)
```