### PR TITLE
Revert "fix(github): Don't open PR as draft"

### DIFF
--- a/lib/pr.js
+++ b/lib/pr.js
@@ -76,7 +76,8 @@ module.exports = {
       title: '[' + target + '] ' + origPRTitle,
       head: targetBranch,
       base: target,
-      body: `backport of #${origPRnr}`
+      body: `backport of #${origPRnr}`,
+      draft: draft,
     })
     return context.github.pulls.create(params)
   },


### PR DESCRIPTION
Reverts nextcloud/backportbot#364 because https://github.com/nextcloud/backportbot/pull/366 fixed the PR creation error.