### PR TITLE
fix(cherry-pick): Abort conflicting cherry-pick before fallback

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -46,6 +46,11 @@ module.exports = async function (context, token, commits, target, logger) {
         ])
       } catch (error) {
         conflicts = true
+        logger.error('Cherry-pick failed. Abort and try with --strateg-option=ours', error)
+        await git.raw([
+          'cherry-pick',
+          '--abort',
+        ])
 
         await git.raw([
           'cherry-pick',


### PR DESCRIPTION
Fixes 

```
10:09:48.548Z ERROR probot: Backport to stable25 failed
10:09:48.567Z ERROR probot:
  error: Cherry-picking is not possible because you have unmerged files.
  hint: Fix them up in the work tree, and then use 'git add/rm <file>'
  hint: as appropriate to mark resolution and make a commit.
  fatal: cherry-pick failed
  
  --
  Error: error: Cherry-picking is not possible because you have unmerged files.
  hint: Fix them up in the work tree, and then use 'git add/rm <file>'
  hint: as appropriate to mark resolution and make a commit.
  fatal: cherry-pick failed
  
      at toError (/app/node_modules/simple-git/promise.js:90:14)
      at /app/node_modules/simple-git/promise.js:61:36
      at Git.<anonymous> (/app/node_modules/simple-git/src/git.js:633:18)
      at Function.Git.fail (/app/node_modules/simple-git/src/git.js:1475:18)
      at fail (/app/node_modules/simple-git/src/git.js:1433:20)
      at /app/node_modules/simple-git/src/git.js:1442:16
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
``` 

Leftover of https://github.com/nextcloud/backportbot/pull/362