### PR TITLE
fix(reviews): Only request reviews for the backports from the approvers

### DIFF
--- a/lib/pr.js
+++ b/lib/pr.js
@@ -68,7 +68,7 @@ module.exports = {
       additions: pull.data.additions,
       deletions: pull.data.deletions,
     }
-  
+
   },
 
   newReady: async function (context, origPRnr, origPRTitle, target, targetBranch, draft) {
@@ -140,13 +140,9 @@ More info at https://docs.nextcloud.com/server/latest/developer_manual/getting_s
   },
 
   getReviewers: async function (context) {
-    const reviewers1 = await context.github.pulls.listReviewRequests(context.issue())
-    const reviewers2 = await context.github.pulls.listReviews(context.issue())
-
-    const reviewIds1 = reviewers1.data.users.map(reviewer => reviewer.login)
-    const reviewIds2 = reviewers2.data.map(reviewer => reviewer.user.login)
-
-    return reviewIds1.concat(reviewIds2)
+    const reviews = await context.github.pulls.listReviews(context.issue())
+    const reviewers = reviews.filter(review => review.state === 'APPROVED')
+    return reviewers.data.map(reviewer => reviewer.user.login)
   },
 
   requestReviewers: async function (context, issueId, reviewers) {


### PR DESCRIPTION
This should help to reduce the notification flood for people that did not have time to review the original PR either.

---

This is a blind attempt following https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28 assuming that is how it behaves. How can the bot be tested?