### PR TITLE
fix(logging): stateg(y) typo

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -46,7 +46,7 @@ module.exports = async function (context, token, commits, target, logger) {
         ])
       } catch (error) {
         conflicts = true
-        logger.error('Cherry-pick failed. Abort and try with --strateg-option=ours', error)
+        logger.error('Cherry-pick failed. Abort and try with --strategy-option=ours', error)
         await git.raw([
           'cherry-pick',
           '--abort',


### PR DESCRIPTION
Fixes a typo in the log message about the merge strategy fallback.