### PR TITLE
feat(git): Add `[skip ci]` to conflicting cherry-picks

### DIFF
--- a/lib/backport.js
+++ b/lib/backport.js
@@ -76,7 +76,7 @@ module.exports = async function (context, targets, logger) {
       const commitsList = isCherryPicked ? target.commits : commits
       logger.debug('Backporting commits', commitsList.join(', '), 'to', target.branch)
 
-      const { backportBranch, conflicts } = await git(context, token, commitsList, target.branch, logger)
+      const { backportBranch, conflicts, hasSkipCi } = await git(context, token, commitsList, target.branch, logger)
 
       // Open PR
       const newPR = await pullRequest.newReady(context, pr.data.number, pr.data.title, target.branch, backportBranch, conflicts)
@@ -93,10 +93,26 @@ module.exports = async function (context, targets, logger) {
 
       if (conflicts) {
         logger.warn('Conflicts when cherry-picking from ' + oldBranch + ' to branch ' + backportBranch + ' prevented with --strategy=ours')
-        await pullRequest.updatePRBody(context, newPrId, `- [ ] :warning: This backport had conflicts that were resolved with the 'ours' merge strategy and is likely incomplete\n\nBackport of #${pr.data.number}`)
+        let prDescription = `Backport of #${pr.data.number}
+
+:warning: This backport had conflicts that were resolved with the 'ours' merge strategy and is likely incomplete.
+
+## Todo
+- [ ] Review and resolve any conflicts
+`
+        if (hasSkipCi) {
+          prDescription += `- [ ] Amend HEAD commit to remove '[skip ci]'`
+        }
+        await pullRequest.updatePRBody(context, newPrId, prDescription)
       } else if (!isCherryPicked && diffChanges) {
         logger.warn('Diff changes when cherry-picking from ' + oldBranch + ' to branch ' + backportBranch)
-        await pullRequest.updatePRBody(context, newPrId, `- [ ] :warning: This backport's changes differ from the original and might be incomplete\n\nBackport of #${pr.data.number}`)
+        await pullRequest.updatePRBody(context, newPrId, `Backport of #${pr.data.number}
+
+:warning: This backport's changes differ from the original and might be incomplete
+
+## Todo
+- [ ] Review and resolve any conflicts
+        `)
       }
 
       // Set available milestone

--- a/lib/git.js
+++ b/lib/git.js
@@ -15,6 +15,7 @@ module.exports = async function (context, token, commits, target, logger) {
   const number = pr.getNumber(context)
   const backportBranch = 'backport/' + number + '/' + target
   let conflicts = false
+  let hasSkipCi = false
   try {
     // Clone
     const slug = context.repo().owner + '/' + context.repo().repo
@@ -52,14 +53,40 @@ module.exports = async function (context, token, commits, target, logger) {
           '--abort',
         ])
 
-        await git.raw([
-          'cherry-pick',
-          commits[i],
-          '--strategy-option',
-          'ours'
-        ], (err, result) => {
-          logger.info(err, result)
-        })
+        let originalCommitMessage = undefined
+        try {
+          const commitLog = await git.log({
+            from: commits[i],
+            to: `${commits[i]}~1`,
+            multiLine: true,
+          })
+          originalCommitMessage = commitLog.latest.body
+        } catch (error) {
+          logger.error('Could not get original commit ' + commits[i] + ' from git log')
+        }
+
+        try {
+          if (originalCommitMessage) {
+            await git.raw([
+              'cherry-pick',
+              commits[i],
+              '--strategy-option',
+              'ours',
+              '-e',
+              originalCommitMessage + '\n\n[skip ci]'
+            ])
+          } else {
+            await git.raw([
+              'cherry-pick',
+              commits[i],
+              '--strategy-option',
+              'ours'
+            ])
+          }
+        } catch(error) {
+          logger.error('Cherry-pick failed with --strategy-option=ours too', error)
+          throw error
+        }
       }
     }
 
@@ -77,5 +104,6 @@ module.exports = async function (context, token, commits, target, logger) {
   return {
     backportBranch,
     conflicts,
+    hasSkipCi
   }
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/backportbot/issues/361

A backport can run through three scenarios
1) Cherry-pick passes -> :sunglasses: 
2) Cherry-pick fails but passes with --strategy-option=ours -> troublesome PR -> skip CI
3) Cherry-pick fails with both strategies -> no PR, no CI

The changes are fully untested. Review with care.